### PR TITLE
FEAT: 약 검색 기능 개발

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -169,7 +169,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/screen/screen_home.dart
+++ b/lib/screen/screen_home.dart
@@ -35,17 +35,17 @@ class _HomeScreenState extends State<HomeScreen> {
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
                   Padding(
-                    padding: EdgeInsets.only(left: 15),
+                    padding: EdgeInsets.only(left: 5),
                     child: Text(
                       '$user님 안녕하세요',
                       style: const TextStyle(
-                          fontSize: 24, fontWeight: FontWeight.w900),
+                          fontSize: 22, fontWeight: FontWeight.w900),
                     ),
                   ),
                   IconButton(
                     icon: const Icon(
                       Icons.arrow_forward_ios,
-                      size: 24,
+                      size: 21,
                     ),
                     onPressed: () {
                       Navigator.pushNamed(context, '/user');
@@ -121,6 +121,8 @@ class _HomeScreenState extends State<HomeScreen> {
                   ),
                 ),
               ),
+              SizedBox(height: 30),
+
             ],
           ),
         ),

--- a/lib/screen/screen_login.dart
+++ b/lib/screen/screen_login.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
-
 import '../services/service_auth.dart';
+import '../widgets/widget_custom_textFormField.dart';
 
 class Login extends StatelessWidget {
-
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
 
@@ -16,9 +15,7 @@ class Login extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            SizedBox(
-              height: 100,
-            ),
+            SizedBox(height: 100),
             Row(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
@@ -29,68 +26,24 @@ class Login extends StatelessWidget {
               ],
             ),
             SizedBox(height: 20),
-            Container(
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(10),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.1),
-                    spreadRadius: 3,
-                    blurRadius: 2,
-                    offset: Offset(0, 3),
-                  ),
-                ],
-              ),
-              child: TextFormField(
-                controller: emailController,
-                keyboardType: TextInputType.emailAddress,
-                decoration: InputDecoration(
-                  border: OutlineInputBorder(),
-                  enabledBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(10),
-                      borderSide: BorderSide(color: Colors.white),
-                  ),
-                  focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(10),
-                      borderSide: BorderSide(
-                        color: Color(0xFF98CBFA),
-                      )),
+            Column(
+              children: <Widget>[
+                CustomTextFormField(
+                  keyboardType: TextInputType.emailAddress,
                   labelText: '이메일',
-                  hintText: 'email@example.com',
+                  hintText: 'example@gmail.com',
+                  controller: emailController,
+                  isPassword: false,
                 ),
-              ),
-            ),
-            SizedBox(height: 20),
-            Container(
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(10),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.1),
-                    spreadRadius: 3,
-                    blurRadius: 2,
-                    offset: Offset(0, 3),
-                  ),
-                ],
-              ),
-              child: TextFormField(
-                controller: passwordController,
-                obscureText: true,
-                decoration: InputDecoration(
-                  border: OutlineInputBorder(),
-                  enabledBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(10),
-                      borderSide: BorderSide(color: Colors.white)),
-                  focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(10),
-                      borderSide: BorderSide(
-                        color: Color(0xFF98CBFA),
-                      )),
+                SizedBox(height: 20),
+                CustomTextFormField(
                   labelText: '비밀번호',
-                ),
-              ),
+                  hintText: '비밀번호 입력',
+                  controller: passwordController,
+                  keyboardType: TextInputType.visiblePassword,
+                  isPassword: true,
+                )
+              ],
             ),
             SizedBox(height: 20),
             Row(
@@ -132,7 +85,8 @@ class Login extends StatelessWidget {
                     TextSpan(text: '계정이 없으신가요? '),
                     TextSpan(
                         text: '회원가입',
-                        style: TextStyle(color: Color(0xFF2144FF))),
+                        style: TextStyle(color: Color(0xFF2144FF)),
+                    ),
                     TextSpan(text: '하기'),
                   ],
                 ),

--- a/lib/screen/screen_medicine_info.dart
+++ b/lib/screen/screen_medicine_info.dart
@@ -1,0 +1,141 @@
+import 'package:doctor_nyang/screen/screen_medicine_regist.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+import '../services/globals.dart';
+
+class MedicineInfo extends StatefulWidget {
+  final String name;
+
+  MedicineInfo({required this.name});
+
+  @override
+  _MedicineInfoState createState() => _MedicineInfoState();
+}
+
+class _MedicineInfoState extends State<MedicineInfo> {
+  Map<String, dynamic> medicineInfo = {};
+  bool showMoreInfo = false;
+
+  @override
+  void initState() {
+    super.initState();
+    fetchMedicineInfo();
+  }
+
+  Future<void> fetchMedicineInfo() async {
+    final type = '0';
+    final response = await http.get(Uri.parse('$baseUrl/medicine/${widget.name}/$type'));
+
+    if (response.statusCode == 200) {
+      final data = json.decode(utf8.decode(response.bodyBytes));
+
+      setState(() {
+        medicineInfo = {
+          'itemName': data['itemName'] ?? '제품명 정보 없음',
+          'efcyQesitm': data['efcyQesitm'] ?? '효능 정보 없음',
+          'useMethodQesitm': data['useMethodQesitm'] ?? '사용법 정보 없음',
+          'atpnWarnQesitm': data['atpnWarnQesitm'] ?? '주의사항 경고 정보 없음',
+          'atpnQesitm': data['atpnQesitm'] ?? '약의 사용상 주의사항 정보 없음',
+          'intrcQesitm': data['intrcQesitm'] ?? '상호작용 정보 없음',
+          'seQesitm': data['seQesitm'] ?? '부작용 정보 없음',
+          'depositMethodQesitm': data['depositMethodQesitm'] ?? '보관법 정보 없음',
+        };
+      });
+
+    } else {
+      throw Exception('Failed to load medicine info');
+    }
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.name,style: TextStyle(fontSize: 16),),
+      ),
+      body: medicineInfo.isNotEmpty
+          ? SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              InfoTextWidget(MedicineName: '제품명', content: medicineInfo['itemName']),
+              InfoTextWidget(MedicineName: '효능', content: medicineInfo['efcyQesitm']),
+              InfoTextWidget(MedicineName: '사용법', content: medicineInfo['useMethodQesitm']),
+              if (showMoreInfo) ...[
+                InfoTextWidget(MedicineName: '약의 사용상 주의사항', content: medicineInfo['atpnQesitm']),
+                InfoTextWidget(MedicineName: '상호작용', content: medicineInfo['intrcQesitm']),
+                InfoTextWidget(MedicineName: '부작용', content: medicineInfo['seQesitm']),
+                InfoTextWidget(MedicineName: '보관법', content: medicineInfo['depositMethodQesitm']),
+              ],
+              TextButton(
+                onPressed: () {
+                  setState(() {
+                    showMoreInfo = !showMoreInfo;
+                  });
+                },
+                child: Text('추가 정보 더 보기',style: TextStyle(color: Color(0xFF969696)),textAlign: TextAlign.center,),
+              ),
+            ],
+          ),
+        ),
+      )
+          : Center(child: CircularProgressIndicator()),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 0,horizontal: 20),
+          child: TextButton(
+            style: TextButton.styleFrom(
+              backgroundColor: Color(0xFFDCF4FF),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => MedicineRegist(name: widget.name),
+                ),
+              );
+            },
+            child: Text(
+              '등록하기',
+              style: TextStyle(color: Colors.black),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+
+class InfoTextWidget extends StatelessWidget {
+  final String MedicineName;
+  final String? content;
+
+  const InfoTextWidget({
+    Key? key,
+    required this.MedicineName,
+    this.content,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final dosageInfoText = (content == null || content!.isEmpty) ? '정보 없음' : content;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(MedicineName, style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: Color(0xFF969696))),
+        Text(dosageInfoText!, style: TextStyle(fontSize: 14)),
+        SizedBox(height: 10),
+      ],
+    );
+  }
+}

--- a/lib/screen/screen_medicine_regist.dart
+++ b/lib/screen/screen_medicine_regist.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+
+class MedicineRegist extends StatefulWidget {
+  late final String name;
+
+  MedicineRegist({required this.name});
+
+  @override
+  _MedicineRegistState createState() => _MedicineRegistState();
+}
+
+class _MedicineRegistState extends State<MedicineRegist> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('복용 일정 추가하기', style: TextStyle(fontSize: 16),),
+      ),
+      body: Padding(padding: EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+          child: Column(
+
+          )
+      ),
+    );
+  }
+}

--- a/lib/screen/screen_medicine_search.dart
+++ b/lib/screen/screen_medicine_search.dart
@@ -1,0 +1,112 @@
+import 'package:doctor_nyang/screen/screen_medicine_info.dart';
+import 'package:doctor_nyang/services/globals.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+class MedicineSearch extends StatefulWidget {
+  @override
+  _MedicineSearchState createState() => _MedicineSearchState();
+}
+
+class _MedicineSearchState extends State<MedicineSearch> {
+  List<dynamic> searchResults = [];
+
+  Future<void> searchMedicines(String query) async {
+    final response = await http.get(Uri.parse('$baseUrl/medicine/$query'));
+    final decodedResponse = utf8.decode(response.bodyBytes);
+
+    if (response.statusCode == 200) {
+      final data = json.decode(decodedResponse) as List;
+
+      List<String> processedData = data.map<String>((item) {
+        String itemStr = item as String;
+        List<String> parts = itemStr.split('(');
+        return parts.first.trim();
+      }).toList();
+
+      setState(() {
+        searchResults = processedData;
+      });
+    } else {
+      throw Exception('Failed to load medicines');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(kToolbarHeight),
+        child: Container(
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Colors.grey.shade300,
+                blurRadius: 10.0,
+                spreadRadius: 0.1,
+                offset: Offset(0, 1),
+              ),
+            ],
+            color: Colors.white,
+          ),
+          child: AppBar(
+            backgroundColor: Colors.transparent,
+            elevation: 0,
+            leading: IconButton(
+              icon: Icon(Icons.arrow_back_ios),
+              onPressed: () {},
+            ),
+            actions: <Widget>[
+              SizedBox(
+                width: 50,
+              ),
+              Flexible(
+                child: TextField(
+                  decoration: InputDecoration(
+                      border: InputBorder.none, hintText: '검색어 입력'),
+                  onChanged: (text) {
+                    searchMedicines(text);
+                  },
+                ),
+              ),
+              IconButton(
+                icon: Icon(Icons.search),
+                onPressed: () {
+
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+      body: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+        child: ListView.builder(
+          itemCount: searchResults.length,
+          itemBuilder: (context, index) {
+            String itemName = searchResults[index];
+            return InkWell(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => MedicineInfo(name: itemName),
+                  ),
+                );
+              },
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4.0),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(itemName),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screen/screen_user.dart
+++ b/lib/screen/screen_user.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class UserScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        actions: [
+          IconButton(
+            icon: Icon(Icons.settings),
+            onPressed: () {
+              // 설정 기능 나중에 넣기
+            },
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 20),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start, // 새로운 줄
+          children: <Widget>[
+            SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                CircleAvatar(
+                  radius: 40,
+                  backgroundColor: Colors.grey,
+                ),
+                SizedBox(width: 10),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('이름',style: TextStyle(fontSize: 20),),
+                    SizedBox(height: 5),
+                    Text('111@gmail.com'),
+                  ],
+                ),
+              ],
+            ),
+            SizedBox(height: 20),
+            Text('기능 목록',style: TextStyle(fontSize: 16)),
+            Divider(),
+            ListTile(
+              title: Text('약 복용 루틴'), //임시
+              onTap: () {
+                Navigator.pushNamed(context, '/PillSchedule');
+              },
+            ),
+            ListTile(
+              title: Text('약물 추가 화면'), //임시
+              onTap: () {
+                Navigator.pushNamed(context, '/DosageSearch');
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/globals.dart
+++ b/lib/services/globals.dart
@@ -1,0 +1,1 @@
+final String baseUrl = "http://localhost:8080";

--- a/lib/services/service_auth.dart
+++ b/lib/services/service_auth.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
+import 'globals.dart';
+
 Future<void> login(String id, String password, BuildContext context) async {
-  final String baseUrl = "http://localhost:8080";
   final url = Uri.parse('$baseUrl/user/login');
 
   try {
@@ -25,11 +26,18 @@ Future<void> login(String id, String password, BuildContext context) async {
           print('$id, 로그인 성공');
           Navigator.pushNamed(context, '/MyHomePage');
           break;
-        case 400:
+        case 100:
           print('로그인 실패: 아이디가 존재하지 않음');
           break;
-        case 500:
+        case 300:
           print('로그인 실패: 비밀번호 오류');
+          break;
+        case 201:
+          print('첫 로그인: 튜토리얼 진행 필요');
+          Navigator.pushNamed(context, '/MyHomePage');
+          break;
+        case 400:
+          print('유저 정보를 찾을 수 없음');
           break;
         default:
           print('알 수 없는 오류');
@@ -64,10 +72,16 @@ Future<void> register(String id, String password, String nickname, String birthD
       switch (responseData) {
         case 200:
           print('$id,$nickname,$birthDate, 회원가입 성공');
-          Navigator.pushNamed(context, '/login');
+          Navigator.pushNamed(context, '/MyHomePage');
+          break;
+        case 100:
+          print('$id,$nickname,$birthDate,회원가입 실패: 아이디 중복');
           break;
         case 400:
-          print('$id,$nickname,$birthDate,회원가입 실패: 아이디 중복');
+          print('$id,$nickname,$birthDate,유효하지 않은 BMR 값');
+          break;
+        case 500:
+          print('$id,$nickname,$birthDate,유효하지 않은 BMI 값');
           break;
         default:
           print('$id,$nickname,$birthDate,알 수 없는 오류');

--- a/lib/widgets/widget_custom_textFormField.dart
+++ b/lib/widgets/widget_custom_textFormField.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+class CustomTextFormField extends StatelessWidget {
+  final String labelText;
+  final String hintText;
+  final TextEditingController controller;
+  final bool isPassword;
+  final TextInputType keyboardType;
+
+  const CustomTextFormField({
+    Key? key,
+    required this.labelText,
+    required this.hintText,
+    required this.controller,
+    this.isPassword = false,
+    required this.keyboardType,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(10),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.1),
+            spreadRadius: 3,
+            blurRadius: 2,
+            offset: Offset(0, 3),
+          ),
+        ],
+      ),
+      child: TextFormField(
+        controller: controller,
+        keyboardType: keyboardType,
+        obscureText: isPassword,
+        decoration: InputDecoration(
+          border: OutlineInputBorder(),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(10),
+            borderSide: BorderSide(color: Colors.white),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(10),
+            borderSide: BorderSide(color: Color(0xFF98CBFA)),
+          ),
+          labelText: labelText,
+          hintText: hintText,
+          fillColor: Colors.white,
+          filled: true,
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -115,6 +115,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -127,34 +151,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   percent_indicator:
     dependency: "direct main"
     description:
@@ -232,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## 개요
약 검색 화면 개발 및 로그인 텍스트필드 위젯으로 변경


### 추가된 사항
medicine_info -> 약품 정보 화면 (제품명 효능 사용법 기본으로 띄워줌 아래 추가 정보 더 보기 버튼 클릭 시 주의사항, 상호작용, 부작용, 보관법 표시)
medicine_regist -> 약품 등록 화면 (스크린만 만들어놓음)
medicine_search -> 약품 검색 화면 (검색어 작성 시 관련 약품 10개까지 표시)

### 변경 사항
로그인 화면(screen_login) customTextFormField 위젯을 통해 중복되는 decoration 제외 controller, keyboardType, obscureText 추가 설정할 수 있도록 변경
로그인 API 오류 수정


## 이미지
시각적인 설명이 필요한 경우 부가적으로 첨부해주세요.

<img width="369" alt="스크린샷 2024-03-28 오후 8 18 20" src="https://github.com/salt-bread-tech/doctor-nyang/assets/100851180/b5316c91-be21-4811-8073-aba522472343">

약품 검색 화면 (medicine search)

<img width="361" alt="스크린샷 2024-03-28 오후 8 19 05" src="https://github.com/salt-bread-tech/doctor-nyang/assets/100851180/55326465-cdee-41ed-8a10-d94d54877d7a">

약품 정보 화면 (medicine info)

<img width="365" alt="스크린샷 2024-03-28 오후 8 19 46" src="https://github.com/salt-bread-tech/doctor-nyang/assets/100851180/87e5d671-09fd-4a6e-92bc-b1d56e6a6546">

약품 정보 화면2 (medicine info 2) -> 추가 정보 더 보기 클릭 후